### PR TITLE
Don't treat empty endpoint links as invalid

### DIFF
--- a/html_test.go
+++ b/html_test.go
@@ -16,35 +16,36 @@ import (
 func TestHtmlLink(t *testing.T) {
 	tests := []struct {
 		input, want string
+		wantErr     error
 	}{
 		// basic links
-		{`<link href="foo" rel="webmention">`, "foo"},
-		{`<a href="foo" rel="webmention">`, "foo"},
+		{`<link href="foo" rel="webmention">`, "foo", nil},
+		{`<a href="foo" rel="webmention">`, "foo", nil},
 		// different attribute order
-		{`<link rel="webmention" href="foo">`, "foo"},
+		{`<link rel="webmention" href="foo">`, "foo", nil},
 		// line breaks inside element
 		{`<link
 			rel="webmention" 
-			href="foo">`, "foo"},
+			href="foo">`, "foo", nil},
 		// multiple rel values
-		{`<link rel="a webmention b" href="foo">`, "foo"},
+		{`<link rel="a webmention b" href="foo">`, "foo", nil},
 		// legacy rel value
-		{`<link rel="http://webmention.org" href="foo">`, "foo"},
+		{`<link rel="http://webmention.org" href="foo">`, "foo", nil},
 		// legacy rel value with slash
-		{`<link rel="http://webmention.org/" href="foo">`, "foo"},
+		{`<link rel="http://webmention.org/" href="foo">`, "foo", nil},
 		// invalid legacy rel value
-		{`<link rel="https://webmention.org" href="foo">`, ""},
+		{`<link rel="https://webmention.org" href="foo">`, "", errNoWebmentionRel},
 		// no rel value
-		{`<link href="foo">`, ""},
+		{`<link href="foo">`, "", errNoWebmentionRel},
 		// multiple links, only one for webmention
-		{`<a href="foo" rel="web"><a href="bar" rel="webmention">`, "bar"},
+		{`<a href="foo" rel="web"><a href="bar" rel="webmention">`, "bar", nil},
 		// multiple webmention links, return first
-		{`<a href="foo" rel="webmention"><a href="bar" rel="webmention">`, "foo"},
+		{`<a href="foo" rel="webmention"><a href="bar" rel="webmention">`, "foo", nil},
 	}
 
 	for _, tt := range tests {
 		buf := bytes.NewBufferString(tt.input)
-		if got, err := htmlLink(buf); err != nil {
+		if got, err := htmlLink(buf); err != tt.wantErr {
 			t.Errorf("htmlLink(%q) returned error: %v", tt.input, err)
 		} else if want := tt.want; got != want {
 			t.Errorf("htmlLink(%q) returned %v, want %v", tt.input, got, want)

--- a/http.go
+++ b/http.go
@@ -7,21 +7,24 @@
 package webmention
 
 import (
+	"fmt"
 	"net/http"
 
 	"willnorris.com/go/webmention/third_party/header"
 )
 
+var errNoWebmentionRel = fmt.Errorf("no webmention rel found")
+
 // httpLink parses headers and returns the URL of the first link that contains
 // a webmention rel value.
-func httpLink(headers http.Header) string {
+func httpLink(headers http.Header) (string, error) {
 	for _, h := range header.ParseList(headers, "Link") {
 		link := header.ParseLink(h)
 		for _, v := range link.Rel {
 			if v == relWebmention || v == relLegacy || v == relLegacySlash {
-				return link.Href
+				return link.Href, nil
 			}
 		}
 	}
-	return ""
+	return "", errNoWebmentionRel
 }

--- a/http_test.go
+++ b/http_test.go
@@ -13,19 +13,21 @@ import (
 
 func TestHttpLink(t *testing.T) {
 	tests := []struct {
-		input []string
-		want  string
+		input   []string
+		want    string
+		wantErr error
 	}{
-		{[]string{`<foo>; rel="webmention"`}, "foo"},
-		{[]string{`<foo>; rel="a webmention b"`}, "foo"},
-		{[]string{`<foo>; rel="http://webmention.org"`}, "foo"},
-		{[]string{`<foo>; rel="http://webmention.org/"`}, "foo"},
-		{[]string{`<foo>; rel="https://webmention.org"`}, ""},
-		{[]string{`<foo>`}, ""},
-		{[]string{`<foo>; rel="a", <bar>; rel="webmention"`}, "bar"},
-		{[]string{`<foo>; rel="a"`, `<bar>; rel="webmention"`}, "bar"},
-		{[]string{`<foo>; rel="webmention", <bar>; rel="webmention"`}, "foo"},
-		{[]string{`<foo>; rel="webmention"`, `<bar>; rel="webmention"`}, "foo"},
+		{[]string{`<foo>; rel="webmention"`}, "foo", nil},
+		{[]string{`<foo>; rel="a webmention b"`}, "foo", nil},
+		{[]string{`<foo>; rel="http://webmention.org"`}, "foo", nil},
+		{[]string{`<foo>; rel="http://webmention.org/"`}, "foo", nil},
+		{[]string{`<foo>; rel="https://webmention.org"`}, "", errNoWebmentionRel},
+		{[]string{`<foo>`}, "", errNoWebmentionRel},
+		{[]string{`<foo>; rel="a", <bar>; rel="webmention"`}, "bar", nil},
+		{[]string{`<foo>; rel="a"`, `<bar>; rel="webmention"`}, "bar", nil},
+		{[]string{`<foo>; rel="webmention", <bar>; rel="webmention"`}, "foo", nil},
+		{[]string{`<foo>; rel="webmention"`, `<bar>; rel="webmention"`}, "foo", nil},
+		{[]string{`<>; rel="webmention"`}, "", nil},
 	}
 
 	for _, tt := range tests {
@@ -33,8 +35,8 @@ func TestHttpLink(t *testing.T) {
 		for _, i := range tt.input {
 			headers.Add("Link", i)
 		}
-		if got := httpLink(headers); got != tt.want {
-			t.Errorf("httpLink(%q) got %v, want %v", headers, got, tt.want)
+		if got, gotErr := httpLink(headers); got != tt.want || gotErr != tt.wantErr {
+			t.Errorf("httpLink(%q) got %v (error %v), want %v (error %v)", headers, got, gotErr, tt.want, tt.wantErr)
 		}
 	}
 }

--- a/third_party/header/header.go
+++ b/third_party/header/header.go
@@ -115,9 +115,6 @@ type Link struct {
 // call ParseList to split the raw header string into its values.
 func ParseLink(s string) (link Link) {
 	link.Href, s = expectLinkValue(s)
-	if link.Href == "" {
-		return
-	}
 	s = skipSpace(s)
 	for strings.HasPrefix(s, ";") {
 		var pkey string

--- a/third_party/header/header_test.go
+++ b/third_party/header/header_test.go
@@ -68,6 +68,7 @@ func TestParseLink(t *testing.T) {
 	}{
 		{`</foo>; rel="a"`, Link{"/foo", []string{"a"}}},
 		{`</foo>; rel="a b"; rel="c"`, Link{"/foo", []string{"a", "b"}}},
+		{`<>; rel="a"`, Link{"", []string{"a"}}},
 	}
 
 	for _, tt := range tests {

--- a/webmention.go
+++ b/webmention.go
@@ -67,9 +67,6 @@ func (c *Client) DiscoverEndpoint(urlStr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if endpoint == "" {
-		return endpoint, nil
-	}
 
 	// resolve relative endpoint URLs
 	urls, err := resolveReferences(urlStr, endpoint)
@@ -81,7 +78,7 @@ func (c *Client) DiscoverEndpoint(urlStr string) (string, error) {
 
 func extractEndpoint(resp *http.Response) (string, error) {
 	// first check http link headers
-	if endpoint := httpLink(resp.Header); endpoint != "" {
+	if endpoint, err := httpLink(resp.Header); err == nil {
 		return endpoint, nil
 	}
 

--- a/webmention_test.go
+++ b/webmention_test.go
@@ -78,10 +78,10 @@ func TestClient_DiscoverEndpoint(t *testing.T) {
 	})
 
 	want = ""
-	if got, err := client.DiscoverEndpoint(server.URL + "/nolink"); err != nil {
-		t.Errorf("DiscoverEndpoint(%q) returned error: %v", server.URL+"/good", err)
+	if got, err := client.DiscoverEndpoint(server.URL + "/nolink"); err != errNoWebmentionRel {
+		t.Errorf("DiscoverEndpoint(%q) returned error: %v", server.URL+"/nolink", err)
 	} else if got != want {
-		t.Errorf("DiscoverEndpoint(%q) returned %v, want %v", server.URL+"/good", got, want)
+		t.Errorf("DiscoverEndpoint(%q) returned %v, want %v", server.URL+"/nolink", got, want)
 	}
 
 	// empty endpoint is a valid relative URL pointing to the page itself

--- a/webmention_test.go
+++ b/webmention_test.go
@@ -84,6 +84,18 @@ func TestClient_DiscoverEndpoint(t *testing.T) {
 		t.Errorf("DiscoverEndpoint(%q) returned %v, want %v", server.URL+"/good", got, want)
 	}
 
+	// empty endpoint is a valid relative URL pointing to the page itself
+	mux.HandleFunc("/empty", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<link href="" rel="webmention">`)
+	})
+
+	want = server.URL + "/empty" // want absolute URL
+	if got, err := client.DiscoverEndpoint(server.URL + "/empty"); err != nil {
+		t.Errorf("DiscoverEndpoint(%q) returned error: %v", server.URL+"/empty", err)
+	} else if got != want {
+		t.Errorf("DiscoverEndpoint(%q) returned %v, want %v", server.URL+"/empty", got, want)
+	}
+
 	// ensure 404 response is returned as error
 	if _, err := client.DiscoverEndpoint(server.URL + "/bad"); err == nil {
 		t.Errorf("DiscoverEndpoint(%q) did not return expected error", server.URL+"/bad")


### PR DESCRIPTION
An empty string is a valid relative URL that points back to the same page where it is. Both HTTP headers and HTML allow relative URLs. When doing endpoint discovery, those are to be treated as valid values and processed.

Since the empty value was used as an inline error signal, I had to introduce a new error value, have functions return it, and fix some tests to expect it where appropriate.

fixes #12 