### PR TITLE
feat: try HEAD request before GET

### DIFF
--- a/webmention.go
+++ b/webmention.go
@@ -79,13 +79,11 @@ func (c *Client) discoverRequest(method, urlStr string) (string, error) {
 	defer resp.Body.Close()
 
 	if code := resp.StatusCode; code < 200 || 300 <= code {
-		_, _ = io.Copy(io.Discard, resp.Body)
 		return "", fmt.Errorf("response error: %v", resp.StatusCode)
 	}
 
 	endpoint, err := extractEndpoint(resp)
 	if err != nil {
-		_, _ = io.Copy(io.Discard, resp.Body)
 		return "", err
 	}
 


### PR DESCRIPTION
I added the HEAD request first.

I also made sure the body is discarded before closing the connection so the http.Client can reuse the TCP connections. I heard this is needed, but I found contradicting information...

Closes #5 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>